### PR TITLE
feat(jobs): allow admin job deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If this is your first time looking at the project, here's a quick tour and some 
     - `GET /api/jobs` — list jobs (search, pagination)
     - `GET /api/jobs/:id` — job details
     - `POST /api/jobs` — create job (**admin only** via Basic Auth)
+    - `DELETE /api/jobs/:id` — delete job (**admin only**)
 - Applications
     - `POST /api/applications` — submit an application (name, email, CV link or cover text)
 - Healthcheck
@@ -239,6 +240,12 @@ curl -X POST http://localhost:8080/api/jobs \
     "location": "Remote",
     "description": "NestJS, MongoDB, AWS"
   }'
+```
+
+### Jobs — Delete (Admin only)
+```bash
+curl -X DELETE http://localhost:8080/api/jobs/<jobId> \
+  -H "Authorization: Basic $(printf 'devAdmin:devPass' | base64)"
 ```
 
 ### Applications — Submit

--- a/src/jobs/controller/jobs.controller.ts
+++ b/src/jobs/controller/jobs.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   Post,
+  Delete,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -74,5 +75,16 @@ export class JobsController {
   @ApiBadRequestResponse({ description: 'Validation error' })
   create(@Body() dto: CreateJobDto) {
     return this.service.create(dto);
+  }
+
+  @Delete(':id')
+  @UseGuards(BasicAuthGuard)
+  @ApiBasicAuth('basic')
+  @ApiOperation({ summary: 'Delete a job (admin only)' })
+  @ApiParam({ name: 'id', description: 'MongoDB ObjectId' })
+  @ApiOkResponse({ description: 'Job deleted' })
+  @ApiNotFoundResponse({ description: 'Job not found' })
+  remove(@Param('id', new ParseObjectIdPipe()) id: string) {
+    return this.service.remove(id);
   }
 }

--- a/src/jobs/service/jobs.service.ts
+++ b/src/jobs/service/jobs.service.ts
@@ -40,4 +40,10 @@ export class JobsService {
     if (!job) throw new NotFoundException('Job not found');
     return job;
   }
+
+  async remove(id: string) {
+    const job = await this.jobModel.findByIdAndDelete(id).lean();
+    if (!job) throw new NotFoundException('Job not found');
+    return { message: 'Job deleted' };
+  }
 }

--- a/test/jobs.controller.spec.ts
+++ b/test/jobs.controller.spec.ts
@@ -16,6 +16,7 @@ describe('JobsController', () => {
             findAll: jest.fn(),
             findOne: jest.fn(),
             create: jest.fn(),
+            remove: jest.fn(),
           },
         },
       ],
@@ -49,5 +50,12 @@ describe('JobsController', () => {
     const res = await controller.create({ title: 'X' } as any);
     expect(service.create).toHaveBeenCalled();
     expect((res as any).id).toBe('1');
+  });
+
+  it('remove calls service.remove', async () => {
+    service.remove.mockResolvedValue({ message: 'Job deleted' } as any);
+    const res = await controller.remove('64d1a47f3d6e2a001f8a1e2c');
+    expect(service.remove).toHaveBeenCalledWith('64d1a47f3d6e2a001f8a1e2c');
+    expect(res).toEqual({ message: 'Job deleted' });
   });
 });

--- a/test/jobs.service.spec.ts
+++ b/test/jobs.service.spec.ts
@@ -1,5 +1,6 @@
 // test/jobs.service.spec.ts
 import { Test } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/mongoose';
 import { JobsService } from '../src/jobs/service/jobs.service';
 
@@ -64,6 +65,15 @@ function makeJobModelMock(seed: any[] = []) {
       return {
         lean: jest.fn(() => found),
         exec: jest.fn(() => found),
+      };
+    }),
+
+    findByIdAndDelete: jest.fn((id: string) => {
+      const idx = state.data.findIndex((d) => String(d._id) === String(id));
+      const deleted = idx >= 0 ? state.data.splice(idx, 1)[0] : null;
+      return {
+        lean: jest.fn(() => deleted),
+        exec: jest.fn(() => deleted),
       };
     }),
   };
@@ -143,5 +153,23 @@ describe('JobsService', () => {
 
     expect(jobModel.findById).toHaveBeenCalled();
     expect(one.title).toBe('X');
+  });
+
+  it('removes a job', async () => {
+    const c = await service.create({
+      title: 'Del',
+      company: 'Corp',
+      location: 'Remote',
+      description: 'to delete',
+      isActive: true,
+    } as any);
+
+    const res = await service.remove(String((c as any)._id));
+
+    expect(jobModel.findByIdAndDelete).toHaveBeenCalled();
+    expect(res).toEqual({ message: 'Job deleted' });
+    await expect(service.findOne(String((c as any)._id))).rejects.toThrow(
+      NotFoundException,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add `DELETE /jobs/:id` endpoint for admins
- support job removal in service layer
- document job deletion in README and tests

## Testing
- `npm test`
- `npm run lint`
- `npx tsc -noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac67aa36648327811993078a07718d